### PR TITLE
Add docker compose and using node alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8-alpine
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,9 @@
 FROM node:8-alpine
 
-# Create app directory
-WORKDIR /usr/src/app
-
-# Install app dependencies
-# A wildcard is used to ensure both package.json AND package-lock.json are copied
-# where available (npm@5+)
-COPY package*.json ./
-
-RUN npm install
-# If you are building your code for production
-# RUN npm ci --only=production
-
-# Bundle app source
-COPY . .
+RUN mkdir -p /var/app
+WORKDIR /var/app
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 8080
+ENTRYPOINT ["sh","/docker-entrypoint.sh"]
 CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ In local environment use "localhost:8080"
 
 To create google credential follow [this](https://developers.google.com/identity/sign-in/web/sign-in) steps.
 
+## Running local
+Run the following command on the terminal:
+```sh
+docker compose up
+```
+
+Then access in your browser: http://localhost:8080/
+
 ## We are using the baby steps strategy.
 
 In this moment is possible:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  web:
+    ports:
+     - '8080:8080'
+    build:
+      context: ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,5 +3,7 @@ services:
   web:
     ports:
      - '8080:8080'
+    volumes:
+      - .:/var/app
     build:
       context: ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   web:
+    working_dir: /var/app
     ports:
      - '8080:8080'
     volumes:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,2 @@
+npm install
+exec "$@"


### PR DESCRIPTION
# About
Using docker-compose to start the application in local environment just with `docker-compose up`.

Changing `node:8` to `node:8-alpine`, this reduces the time to build the image.
With `node:8`: 6 minutes and 14 seconds
With `node:8-alpine`: 46 seconds
