### PR TITLE
fix the broadcast to sync room for current logged user

### DIFF
--- a/controllers/office.controller.js
+++ b/controllers/office.controller.js
@@ -24,5 +24,13 @@ OfficeController.prototype.getUsersInOffice = function () {
   return this.usersInRoomOffice;
 };
 
+OfficeController.prototype.getUsersInOfficeByMap = function () {
+    var usersInOffice = new Map();
+    this.getUsersInOffice().forEach((value, key) => {
+        usersInOffice[key] = value;
+    });
+    return usersInOffice;
+};
+
 
 module.exports = OfficeController;

--- a/office.server.js
+++ b/office.server.js
@@ -22,10 +22,7 @@ function Office(server) {
     const room = room_param || 'room-1';
     addUserInRoom(socket.user, room);
 
-    that.officeController.getUsersInOffice().forEach((value, key) => {
-      addUserInRoom(value.user, value.room);
-    });
-
+    socket.emit('sync-office', that.officeController.getUsersInOfficeByMap());
 
     socket.on('disconnect', (socket) => {
       io.sockets.emit('disconnect', currentUser.id);

--- a/public/office.web.js
+++ b/public/office.web.js
@@ -87,6 +87,13 @@ $(() => {
       }, 300);
     });
 
+    socket.on('sync-office', (usersInRoom) => {
+      for (var key in usersInRoom) {
+        userInroom = usersInRoom[key];
+        showUserInRoom(userInroom.user, userInroom.room);
+      }
+    });
+
     socket.on('enter-room', (data) => {
       saveLastRoom(data);
       showUserInRoom(data.user, data.room);
@@ -99,8 +106,9 @@ $(() => {
       }
     });
 
-    socket.on('disconnect', (data) => {
-      removeUser(data, userId);
+    socket.on('disconnect', (userId) => {
+      console.log('disconnect',userId);
+      removeUser(userId);
     });
   }
 });


### PR DESCRIPTION
In this pull request, I fixed the problem when one user enters a room and all users receive the notification about all other users connected.  For example: we have 3 users connected. for convenience when the fifth user enter in room for synchronize him office we loop all connected users and send the event enter-room. After we implemented the web notification. all users receive repetited notification. this pull request solve this problem. because now we send only the sync room for last connected user. 